### PR TITLE
prepare 1.4.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## **1.4.0**
 
+* Add some nicer, opinionated styles for the popup close button.
+  [thet]
+
 * Add option to add some padding to ``fitBounds`` with a default of ``20``.
   This brings search result on corners more in the map.
   [thet]

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## **1.4.0**
 
+* Add option to add some padding to ``fitBounds`` with a default of ``20``.
+  This brings search result on corners more in the map.
+  [thet]
+
 * Add ``extraClasses`` property to marker icons creation.
   This allows for extra classes like a marker uuid to work with.
   [thet]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## **1.4.0**
+
+* Add ``extraClasses`` property to marker icons creation.
+  This allows for extra classes like a marker uuid to work with.
+  [thet]
+
+
 ## **1.3.0**
 
 * Add ``maxClusterRadius`` option for the marker cluster plugin. Default is 80 (pixels).

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## **1.4.0**
 
+* Fix a problem with ``map_layers`` option when it's a list of ids and no title was generated for the baseLayers object.
+  [thet]
+
 * Add some nicer, opinionated styles for the popup close button.
   [thet]
 

--- a/index.html
+++ b/index.html
@@ -79,7 +79,8 @@
         "id": 2,
         "properties": {
           "popup": "hoergeREDE (aut), graz, austria",
-          "color": "purple"
+          "color": "purple",
+          "extraClasses": "pat-leaflet-marker--hoergerede-graz"
         },
         "geometry": {
             "type": "Point",
@@ -145,7 +146,8 @@
         "id": 2,
         "properties": {
           "popup": "hoergeREDE (aut), graz, austria",
-          "color": "#CCCCCC"
+          "color": "purple",
+          "extraClasses": "pat-leaflet-marker--hoergerede-graz"
         },
         "geometry": {
             "type": "Point",

--- a/src/pat-leaflet.css
+++ b/src/pat-leaflet.css
@@ -14,3 +14,27 @@
     height: auto;
     line-height: inherit;
 }
+
+.leaflet-popup {
+    padding: 3rem 3rem 0 3rem;
+}
+.leaflet-popup a.leaflet-popup-close-button.leaflet-popup-close-button {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    padding: 0;
+    font-size: 3rem;
+    color: black;
+    text-shadow:
+        -0.2rem   0      0 white,
+         0.2rem   0      0 white,
+         0       -0.2rem 0 white,
+         0        0.2rem 0 white,
+        -0.2rem   0.2rem 0 white,
+         0.2rem  -0.2rem 0 white,
+        -0.2rem  -0.2rem 0 white,
+         0.2rem   0.2rem 0 white;
+}
+.leaflet-popup a.leaflet-popup-close-button.leaflet-popup-close-button:hover {
+    color: red;
+}

--- a/src/pat-leaflet.js
+++ b/src/pat-leaflet.js
@@ -147,20 +147,21 @@
                 marker_cluster = new L.MarkerClusterGroup({'maxClusterRadius': options.maxClusterRadius});
                 marker_layer = L.geoJson(geojson, {
                     pointToLayer: function(feature, latlng) {
-                        var marker_color = this.create_marker('green');
+                        var extraClasses = feature.properties.extraClasses || '';
+                        var markerColor = 'green';
                         if (feature.properties.color) {
-                          marker_color = this.create_marker(feature.properties.color);
+                            markerColor = feature.properties.color;
                         } else if (!main_marker || feature.properties.main) {
-                            marker_color = this.create_marker('red');
+                            markerColor = 'red';
                         }
+                        var marker_icon = this.create_marker(markerColor, extraClasses);
                         var marker = L.marker(latlng, {
-                            icon: marker_color,
+                            icon: marker_icon,
                             draggable: feature.properties.editable
                         });
                         if (!main_marker || feature.properties.main) {
                             // Set main marker. This is the one, which is used
                             // for setting the search result marker.
-                            marker.icon = this.create_marker('blue');
                             main_marker = marker;
                         }
                         marker.on('dragend move', function (e) {
@@ -305,12 +306,14 @@
             }
         },
 
-        create_marker: function (color) {
+        create_marker: function (color, extraClasses) {
           color = color || 'red';
+          extraClasses = extraClasses || '';
           return L.AwesomeMarkers.icon({
             markerColor: color,
             prefix: 'fa',
-            icon: 'circle'
+            icon: 'circle',
+            extraClasses: extraClasses
           });
         }
 

--- a/src/pat-leaflet.js
+++ b/src/pat-leaflet.js
@@ -49,6 +49,8 @@
 
     parser.addArgument('maxClusterRadius', '80');
 
+    parser.addArgument('boundsPadding', '20');
+
     // default controls
     parser.addArgument('fullscreencontrol', true);
     parser.addArgument('zoomcontrol', true);
@@ -79,6 +81,14 @@
 
         init: function initUndefined () {
             var options = this.options = parser.parse(this.$el);
+
+            var fitBoundsOptions = {
+                maxZoom: options.zoom,
+                padding: [
+                    parseInt(options.boundsPadding),
+                    parseInt(options.boundsPadding)
+                ]
+            }
 
             var baseLayers,
                 bounds,
@@ -185,7 +195,7 @@
                                 marker_cluster.addLayer(marker);
                                 // fit bounds
                                 bounds = marker_cluster.getBounds();
-                                map.fitBounds(bounds);
+                                map.fitBounds(bounds, fitBoundsOptions);
                             });
                         }
                         if (feature.properties.lnginput) {
@@ -197,7 +207,7 @@
                                 marker_cluster.addLayer(marker);
                                 // fit bounds
                                 bounds = marker_cluster.getBounds();
-                                map.fitBounds(bounds);
+                                map.fitBounds(bounds, fitBoundsOptions);
                             });
                         }
                         return marker;
@@ -209,7 +219,7 @@
 
                 // autozoom
                 bounds = marker_cluster.getBounds();
-                map.fitBounds(bounds, {maxZoom: options.zoom});
+                map.fitBounds(bounds, fitBoundsOptions);
             } else {
                 map.setView(
                     [options.latitude, options.longitude],
@@ -245,7 +255,7 @@
                         main_marker.setLatLng(latlng).update();
                         marker_cluster.addLayer(main_marker);
                         // fit to window
-                        map.fitBounds([latlng]);
+                        map.fitBounds([latlng], fitBoundsOptions);
                     } else {
                         e.Marker.setIcon(this.create_marker('red'));
                         this.bind_popup({properties: {editable: true, popup: 'New Marker'}}, e.Marker).bind(this);
@@ -275,7 +285,7 @@
                     main_marker.setLatLng({lat: e.latlng.lat, lng: e.latlng.lng});
                     marker_cluster.addLayer(main_marker);
                 }
-                map.fitBounds([e.latlng]);
+                map.fitBounds([e.latlng], fitBoundsOptions);
             });
 
             // Minimap

--- a/src/pat-leaflet.js
+++ b/src/pat-leaflet.js
@@ -132,7 +132,7 @@
                 // Convert map_layers elements from string to objects, if necesarry
                 options.map_layers = options.map_layers.map(function (it) {
                     if (typeof(it) == 'string' ) {
-                        it = {id: it, options: {}};
+                        it = {id: it, title: it, options: {}};
                     }
                     return it;
                 });


### PR DESCRIPTION
* Fix a problem with ``map_layers`` option when it's a list of ids and no title was generated for the baseLayers object.

* Add some nicer, opinionated styles for the popup close button.

* Add option to add some padding to ``fitBounds`` with a default of ``20``.
  This brings search result on corners more in the map.

* Add ``extraClasses`` property to marker icons creation.
  This allows for extra classes like a marker uuid to work with.
