### PR TITLE
Geojson parsing and new `geojson_ajaxurl` option

### DIFF
--- a/src/leaflet.js
+++ b/src/leaflet.js
@@ -39,6 +39,9 @@ parser.addArgument("map_layers", [
 
 parser.addArgument("image_path", "node_modules/leaflet.awesome-markers/dist/images");
 
+// fetch geojson data via AJAX url
+parser.addArgument("geojson_ajaxurl", "");
+
 export default Base.extend({
     name: "leaflet",
     trigger: ".pat-leaflet",
@@ -130,20 +133,24 @@ export default Base.extend({
         map.setView([options.latitude, options.longitude], options.zoom);
 
         // ADD MARKERS
-        const geojson = this.el.dataset.geojson;
-        if (typeof geojson === "string" && geojson.indexOf(".json") != -1) {
-            // suppose this is a JSON url which ends with ".json" ... try to load it
+        if (options.geojson_ajaxurl !== "") {
             let response;
             try {
-                response = await fetch(geojson);
+                response = await fetch(options.geojson_ajaxurl);
                 const data = await response.json();
                 this.init_geojson(map, data);
             } catch (e) {
+                log.info(`Could not load geojson data from url ${options.geojson_ajaxurl}`);
                 return;
             }
-        } else if (geojson) {
-            // inject inline geoJSON data object
-            this.init_geojson(map, geojson);
+        } else if (this.el.dataset.geojson) {
+            try {
+                // inject inline geoJSON data object
+                this.init_geojson(map, JSON.parse(this.el.dataset.geojson));
+            } catch(e) {
+                log.info("Could not parse geojson data.");
+                return;
+            }
         }
 
         if (options.geosearch) {

--- a/src/leaflet.test.js
+++ b/src/leaflet.test.js
@@ -21,4 +21,85 @@ describe("pat-leaflet", () => {
         expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-out")).toBeTruthy(); // prettier-ignore
         expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-fullscreen")).toBeTruthy(); // prettier-ignore
     });
+
+    it("minimal configuration", async () => {
+        const coords = {
+            lat: 47.33325135,
+            lng: 9.6458777466926851,
+        };
+        document.body.innerHTML = `<div class="pat-leaflet" data-pat-leaflet='{
+            "fullscreencontrol": false,
+            "locatecontrol": false,
+            "zoomcontrol": false,
+            "geosearch": false,
+            "latitude": ${coords.lat},
+            "longitude": ${coords.lng}
+        }' />`;
+        const el = document.querySelector(".pat-leaflet");
+
+        // eslint-disable-next-line no-unused-vars
+        const instance = new Pattern(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(document.querySelector(".pat-leaflet.leaflet-container")).toBeTruthy();
+        expect(document.querySelector(".pat-leaflet .leaflet-pane")).toBeTruthy();
+        expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-in")).toBeFalsy(); // prettier-ignore
+        expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-out")).toBeFalsy(); // prettier-ignore
+        expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-fullscreen")).toBeFalsy(); // prettier-ignore
+
+        // check correct position
+        expect(el["pattern-leaflet"].options.latitude).toBe(coords.lat);
+        expect(el["pattern-leaflet"].options.longitude).toBe(coords.lng);
+    });
+
+    it("load remote geojson", async () => {
+        const coords = {
+            lat: 47.33325135,
+            lng: 9.6458777466926851,
+        };
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "properties": {
+                                "popup": "<h6>Location</h6>",
+                                "color": "red"
+                            },
+                            "geometry": {
+                                "type": "Point",
+                                "coordinates": [
+                                    coords.lng,
+                                    coords.lat
+                                ]
+                            }
+                        }
+                    ]
+                }),
+            })
+        );
+
+        document.body.innerHTML = `<div class="pat-leaflet" data-pat-leaflet='{
+            "fullscreencontrol": false,
+            "locatecontrol": false,
+            "zoomcontrol": false,
+            "geosearch": false,
+            "geojson_ajaxurl": "http://test.url/geodata.json"
+        }' />`;
+        const el = document.querySelector(".pat-leaflet");
+
+        // eslint-disable-next-line no-unused-vars
+        const instance = new Pattern(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(document.querySelector(".pat-leaflet.leaflet-container")).toBeTruthy();
+        expect(document.querySelector(".pat-leaflet .leaflet-pane")).toBeTruthy();
+        expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-in")).toBeFalsy(); // prettier-ignore
+        expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-out")).toBeFalsy(); // prettier-ignore
+        expect(document.querySelector(".pat-leaflet .leaflet-control-zoom-fullscreen")).toBeFalsy(); // prettier-ignore
+        expect(document.querySelector(".pat-leaflet .leaflet-marker-pane")).toBeTruthy();
+        expect(document.querySelector(".pat-leaflet .leaflet-popup-pane")).toBeTruthy();
+    });
 });


### PR DESCRIPTION
Always parse `data-geojson` as JSON object and implement new option `geojson_ajaxurl` for explicitly loading remote geojson data.